### PR TITLE
Update floor3d-card.ts

### DIFF
--- a/src/floor3d-card.ts
+++ b/src/floor3d-card.ts
@@ -2565,8 +2565,8 @@ export class Floor3dCard extends LitElement {
     console.log('Create Room');
 
     const elevation: number = entity.room.elevation ? entity.room.elevation : 250;
-    const transparency: number = entity.room.transparency ? entity.room.transparency : 50;
     const color: string = entity.room.color ? entity.room.color : '#ffffff';
+    const transparency: number = entity.room.transparency ? entity.room.transparency : color == "transparent" ? 100 : 50;
 
     const _foundroom: THREE.Object3D = this._scene.getObjectByName(entity.object_id);
 


### PR DESCRIPTION
Using color "transparent" is still not a valid three color according to the error console but this would allow it to be hidden. put after color line for minification.