### PR TITLE
Allow transparency to be set for room colorcondition

### DIFF
--- a/src/floor3d-card.ts
+++ b/src/floor3d-card.ts
@@ -3103,6 +3103,7 @@ export class Floor3dCard extends LitElement {
           const colorcond: THREE.Color = new THREE.Color(item.colorcondition[i].color);
           _object.material.color.set(colorcond);
           _object.material.emissive.set(colorcond);
+          _room.material.opacity = (100 - item.colorcondition[i].transparency ? item.colorcondition[i].transparency : item.room.transparency) / 100;
           defaultcolor = false;
           break;
         }
@@ -3110,6 +3111,7 @@ export class Floor3dCard extends LitElement {
       if (defaultcolor) {
         _object.material.color.set(color);
         _object.material.emissive.set(color);
+        _room.material.opacity = (100 - item.room.transparency) / 100
       }
     }
   }


### PR DESCRIPTION
This will allow transparency to be specified in the colorcondition. If no state is matched, the default transparency will be used. Using the color name of transparent throws unnecessary console errors.

Example configuration:
```
entities:
  - entity: <an entity>
    type3d: room
    object_id: <a room object (generally the floor) with a name containing "room". >
    room:
      elevation: 254
      transparency: 100 #default if no transparency is specified in colorcondition.
      attribute: state
    colorcondition:
      - color: yellow
        transparency: 80
        state: 'on'
```